### PR TITLE
ci: validate public pull request metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,6 @@
 ## Public-Release Checklist
 
 - [ ] No credentials, private paths, private endpoints, or unpublished artifacts
+- [ ] No agent attribution, generation markers, or session links in commits or public content
 - [ ] Optional hardware/model/data dependencies are documented
 - [ ] Core runtime changes are kept in the main `retriever` repo, not Golden

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v0.70.1
           cache: true
+      - name: Public history guardrail
+        if: github.event_name == 'pull_request'
+        env:
+          PUBLIC_PR_TITLE: ${{ github.event.pull_request.title }}
+          PUBLIC_PR_BODY: ${{ github.event.pull_request.body }}
+        run: >-
+          pixi run python scripts/release/check_public_history.py
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"
       - name: Tests
         run: pixi run test
       - name: Simulation tests (MuJoCo)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,14 @@ one.
 
 - Do not introduce references to private infrastructure, internal
   hostnames, or unpublished project names into this repository.
+- Do not commit conversation transcripts, prompt or tool logs, agent names or
+  identities, model or provider metadata, session links, or agent scratch files.
+  Public code, documentation, artifacts, and commit messages describe project
+  behavior and source provenance, not which assistant produced them.
+- Before pushing or opening a pull request, scan the complete introduced commit
+  range as well as the final tree. CI enforces common attribution and session
+  markers, but maintainers remain responsible for disclosures a pattern cannot
+  recognize.
 
 ## Forbidden actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Repository instructions
+
+See [`AGENTS.md`](AGENTS.md), the single source of truth for repository rules.

--- a/scripts/release/check_public_history.py
+++ b/scripts/release/check_public_history.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Reject public-facing agent attribution from a pull request."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EXCLUDED_DIFF_PATHS = (
+    "AGENTS.md",
+    "scripts/release/check_public_history.py",
+    "tests/release/test_check_public_history.py",
+)
+MARKERS = (
+    (
+        "agent co-author trailer",
+        re.compile(
+            r"(?im)^co-authored-by:\s*[^\n]*"
+            r"(?:claude|codex|chatgpt|anthropic|openai|copilot|gemini|gpt(?:-\d+)?)\b"
+        ),
+    ),
+    (
+        "agent session marker",
+        re.compile(r"(?im)^\s*(?:claude|codex|chatgpt)[-_ ]session\s*:"),
+    ),
+    (
+        "agent generation marker",
+        re.compile(
+            r"(?i)\b(?:generated|created|written)\s+(?:with|by)\s+"
+            r"(?:claude|codex|chatgpt|anthropic|openai|copilot|gemini)\b"
+        ),
+    ),
+)
+AGENT_IDENTITY = re.compile(
+    r"(?i)(?:\b(?:claude|codex|chatgpt|copilot|gemini|gpt(?:-\d+)?)\b|"
+    r"noreply@(?:anthropic|openai)\.com)"
+)
+
+
+def _git(*args: str, repo: Path = ROOT) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode:
+        raise RuntimeError(proc.stderr.strip() or "git command failed")
+    return proc.stdout
+
+
+def find_markers(text: str) -> tuple[str, ...]:
+    return tuple(label for label, pattern in MARKERS if pattern.search(text))
+
+
+def check_commit_range(base: str, head: str, *, repo: Path = ROOT) -> list[str]:
+    failures: list[str] = []
+    commits = _git("rev-list", "--reverse", f"{base}..{head}", repo=repo).splitlines()
+    for commit in commits:
+        message = _git("show", "-s", "--format=%B", commit, repo=repo)
+        markers = find_markers(message)
+        if markers:
+            failures.append(f"commit {commit[:12]}: {', '.join(markers)}")
+
+        identity = _git("show", "-s", "--format=%an%n%ae%n%cn%n%ce", commit, repo=repo)
+        if AGENT_IDENTITY.search(identity):
+            failures.append(f"commit {commit[:12]}: agent author or committer identity")
+    return failures
+
+
+def check_added_lines(base: str, head: str, *, repo: Path = ROOT) -> list[str]:
+    exclusions = [f":(exclude){path}" for path in EXCLUDED_DIFF_PATHS]
+    diff = _git(
+        "diff",
+        "--unified=0",
+        "--no-color",
+        f"{base}...{head}",
+        "--",
+        ".",
+        *exclusions,
+        repo=repo,
+    )
+    failures: list[str] = []
+    path = "unknown"
+    line_number = 0
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)", line)
+            line_number = int(match.group(1)) if match else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            markers = find_markers(line[1:])
+            if markers:
+                failures.append(f"{path}:{line_number}: {', '.join(markers)}")
+            line_number += 1
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.environ.get("PUBLIC_HISTORY_BASE"))
+    parser.add_argument("--head", default=os.environ.get("PUBLIC_HISTORY_HEAD", "HEAD"))
+    args = parser.parse_args()
+    if not args.base:
+        parser.error("--base or PUBLIC_HISTORY_BASE is required")
+
+    try:
+        failures = check_commit_range(args.base, args.head)
+        failures.extend(check_added_lines(args.base, args.head))
+    except RuntimeError as exc:
+        print(f"public history check could not run: {exc}", file=sys.stderr)
+        return 2
+
+    pr_text = "\n".join(
+        (os.environ.get("PUBLIC_PR_TITLE", ""), os.environ.get("PUBLIC_PR_BODY", ""))
+    )
+    markers = find_markers(pr_text)
+    if markers:
+        failures.append(f"pull request title/body: {', '.join(markers)}")
+
+    if failures:
+        print("Public history guardrail failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        print(
+            "Remove agent attribution and session metadata, then rewrite the "
+            "affected commits."
+        )
+        return 1
+
+    print("Public history guardrail passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/check_public_surface.py
+++ b/scripts/release/check_public_surface.py
@@ -19,6 +19,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 REQUIRED_PATHS = (
+    "AGENTS.md",
+    "CLAUDE.md",
     "README.md",
     "examples/advanced/robosuite_lift/app.py",
     "examples/advanced/robosuite_lift/README.md",
@@ -57,6 +59,14 @@ REQUIRED_TASKS = (
 )
 
 DOC_MARKERS = {
+    "AGENTS.md": (
+        "Do not commit conversation transcripts",
+        "complete introduced commit",
+    ),
+    "CLAUDE.md": (
+        "[`AGENTS.md`](AGENTS.md)",
+        "single source of truth",
+    ),
     "README.md": (
         "GoldenRetriever is the applied reference layer",
         "Start Here",

--- a/tests/release/test_check_public_history.py
+++ b/tests/release/test_check_public_history.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.release.check_public_history import (
+    check_added_lines,
+    check_commit_range,
+    find_markers,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def test_markers_reject_agent_metadata_but_allow_product_references() -> None:
+    assert find_markers("Add an OpenAI-compatible planner backend") == ()
+    assert find_markers("Co-Authored-By: Claude <bot@example.com>")
+    assert find_markers("Claude-Session: https://example.invalid/session")
+    assert find_markers("Generated with Codex")
+
+
+def test_commit_range_reports_only_the_introduced_bad_commit(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.name", "Test Maintainer")
+    _git(tmp_path, "config", "user.email", "maintainer@example.com")
+    (tmp_path / "example.txt").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "example.txt")
+    _git(tmp_path, "commit", "-m", "Add example")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+
+    (tmp_path / "example.txt").write_text("updated\n", encoding="utf-8")
+    _git(tmp_path, "add", "example.txt")
+    _git(
+        tmp_path,
+        "commit",
+        "-m",
+        "Update example\n\nCo-Authored-By: Claude <bot@example.com>",
+    )
+
+    failures = check_commit_range(base, "HEAD", repo=tmp_path)
+    assert len(failures) == 1
+    assert "agent co-author trailer" in failures[0]
+
+
+def test_added_public_content_is_checked_separately(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.name", "Test Maintainer")
+    _git(tmp_path, "config", "user.email", "maintainer@example.com")
+    (tmp_path / "README.md").write_text("Public example\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-m", "Add README")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+
+    (tmp_path / "README.md").write_text(
+        "Public example\n\nGenerated with Codex\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-m", "Update README")
+
+    assert check_commit_range(base, "HEAD", repo=tmp_path) == []
+    failures = check_added_lines(base, "HEAD", repo=tmp_path)
+    assert failures == ["README.md:3: agent generation marker"]


### PR DESCRIPTION
## Summary

- validate introduced commit metadata and newly added public content
- document the repository contribution rule in one canonical place
- run the validation in the existing release checks

## Testing

- `pixi run python -m pytest tests/release/test_check_public_history.py -q`
- `pixi run python scripts/release/check_public_surface.py`
- `pixi run test`